### PR TITLE
prevent double calling resetBoard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ class App extends Component {
 
     this.state = {
       newDeck: CardModel.deckFromArrayOfFaces(makeShuffledDeck(length)),
+      isResetting: false,
     }
   }
 
@@ -102,10 +103,17 @@ class App extends Component {
   }
 
   resetBoard(newDeck, timeoutInterval = 1500) {
+    if(this.state.isResetting) {
+      return;
+    }
+    this.setState({
+      isResetting: true,
+    })
     setTimeout(() => {
       newDeck = resetDeck(newDeck);
       this.setState({
         newDeck: newDeck,
+        isResetting: false,
       })
     }, timeoutInterval);
 


### PR DESCRIPTION
I believe this will fix https://github.com/willmurphyscode/react-memory-game/issues/1 by preventing multiple timeouts from being on the event loop at the same time. 